### PR TITLE
correct action generation

### DIFF
--- a/generators/csharp/procedures.js
+++ b/generators/csharp/procedures.js
@@ -40,7 +40,7 @@ Blockly.CSharp.procedures_defreturn = function() {
       append_to_list(argTypes, 'dynamic');
   }
 
-  var delegateType = (returnValue.length == 0) ? 'Action' : ('Func<' + argTypes + '>');
+  var delegateType = (returnValue.length == 0) ? (args.length == 0 ? 'Action' : ('Action<' + argTypes + '>')) : ('Func<' + argTypes + '>');
 
   var code = 'var ' + funcName + ' = new ' + delegateType + '((' + args.join(', ') + ') => {\n' + branch + returnValue + '});';
   code = Blockly.CSharp.scrub_(this, code);


### PR DESCRIPTION
If blocks contain Action block(no return parametres) the program doesn't compile. This changes fix the bug